### PR TITLE
fix a bug of scrolling to top of page after clicking the images

### DIFF
--- a/source/js/img_zoom.js
+++ b/source/js/img_zoom.js
@@ -9,6 +9,9 @@ document.addEventListener("DOMContentLoaded", function(event) {
     Array.prototype.filter.call(images, function(img){
         wrap_image_with_fancybox(img);
     });
+
+    // prevent returning to the top of the page after loading the fancybox
+    $.fancybox.defaults.hideScrollbar = false;
 });
 
 


### PR DESCRIPTION
## Check List

**Please read and check followings before submitting a PR.**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Translation languages
    - [ ] `en` English
    - [ ] `ko` Korean
    - [ ] `pt-br` Brazilian Portuguese
    - [ ] `ru` Russian
    - [ ] `th` Thai
    - [ ] `zh-cn` simplified Chinese
    - [ ] `zh-tw` traditional Chinese
    - You can add more..
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

I just found a bug that the page would return to the top after you click the images and zoom in.
However, the bug has been fixed by adding one-line code.
Sorry for the bug, I should have tested more carefully.

Mainly refers to: https://github.com/fancyapps/fancybox/issues/1093